### PR TITLE
Add a lakefile for the LEAP Lean solutions

### DIFF
--- a/leap/.gitignore
+++ b/leap/.gitignore
@@ -1,0 +1,2 @@
+.lake/
+lake-manifest.json

--- a/leap/lakefile.lean
+++ b/leap/lakefile.lean
@@ -1,0 +1,24 @@
+import Lake
+open Lake DSL
+
+package leap
+
+require mathlib from git
+  "https://github.com/leanprover-community/mathlib4" @ "v4.21.0"
+
+lean_lib «Putnam-2025» where
+  srcDir := "solutions"
+  globs := #[.submodules `«Putnam-2025»]
+
+lean_lib «LEAN-IMO-Bench» where
+  srcDir := "solutions"
+  globs := #[.submodules `«LEAN-IMO-Bench»]
+
+lean_lib «Open-Problems» where
+  srcDir := "solutions"
+  globs := #[.submodules `«Open-Problems»]
+
+@[default_target]
+lean_lib LeapAll where
+  srcDir := "solutions"
+  globs := #[.submodules `«Putnam-2025», .submodules `«LEAN-IMO-Bench», .submodules `«Open-Problems»]

--- a/leap/lean-toolchain
+++ b/leap/lean-toolchain
@@ -1,0 +1,1 @@
+leanprover/lean4:v4.21.0


### PR DESCRIPTION
The `leap/solutions` corpus currently ships as standalone `.lean` files with no build configuration, so verifying that the proofs compile requires manual setup.

This PR adds a minimal `lakefile.lean` + `lean-toolchain` (and a `.gitignore` for lake artifacts) pinning **Lean/mathlib v4.21.0** — the toolchain of [AxiomMath/putnam2025](https://github.com/AxiomMath/putnam2025), which the Putnam solutions target. With it:

```
cd leap && lake exe cache get && lake build
```

compiles **31 of the 58 solution files** out of the box, including the Putnam 2025 set. The remaining files (mostly under `LEAN-IMO-Bench`) appear to target a different mathlib vintage — e.g. they reference `Finset.card_sdiff_of_subset`, which does not exist in v4.21 — so a per-directory pin (or a note of the intended versions) would be needed to make the whole corpus checkable; happy to adjust if the team can share the versions used.

Motivation: we've been measuring structural quality metrics across Lean corpora (reuse graphs, hygiene, elaboration cost — https://vilin97.github.io/lean-code-reuse/), and machine-checkability of published proof corpora is the first gate for any such analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pxj7RaxUiRdq8SmQm3iKg