### PR TITLE
Fix AnswerBench algebra-036 CSV alignment

### DIFF
--- a/imobench/answerbench_v2.csv
+++ b/imobench/answerbench_v2.csv
@@ -151,7 +151,7 @@ imo-bench-algebra-036,"Find all functions $Y: \mathbb{R} \backslash\{0\} \righta
 \[
 a Y\left(a+\frac{1}{b}\right)+b Y(b)+\frac{a}{b}=b Y\left(b+\frac{1}{a}\right)+a Y(a)+\frac{b}{a}
 \]
-,"$Y(x)=A+\frac{B}{x}-x$",Algebra,Functional Equation,Iran 2002
+","$Y(x)=A+\frac{B}{x}-x$",Algebra,Functional Equation,Iran 2002
 imo-bench-algebra-037,"Find all functions $X: \mathbb{C} \rightarrow \mathbb{C}$ such that the equation
 $$X(X(a)+b X(b)-b-1)=1+a+|b|^{2}$$
 holds for all complex numbers $a,b\in \mathbb{C}$ and that $X(1)=u$ for some $u\in \mathbb{C}$ such that $|u-1|=1$.


### PR DESCRIPTION
## Summary

- close the unterminated `Problem` field for `imo-bench-algebra-036`
- restore `$Y(x)=A+\frac{B}{x}-x$` to the `Short Answer` column
- leave every other byte in `answerbench_v2.csv` unchanged

Fixes #13.

## Root cause

The multiline problem statement was missing its closing CSV quote, so the answer and remaining metadata were parsed as five fields instead of the six columns declared by the header.

## Validation

- Python's standard-library CSV reader parses all 400 data records with exactly six fields.
- `imo-bench-algebra-036` has the expected short answer, category, subcategory, and source.
- A separate byte-level checker confirms the candidate differs from current `main` by exactly one inserted `0x22` byte.
- The repaired file has SHA-256 `0c05a0d4af9cbe3e70413b250d6c9cac1bfe4d848f6c196f83ed61ebef9ced16`.

The reproducible validation packet is available at https://proofs.charliekrug.com/publications/deepmind-superhuman-13-answerbench-column-20260722-170424-418499/.
